### PR TITLE
Importing UIKit instead of Foundation for Swift Compatibility

### DIFF
--- a/MAThemeKit/MAThemeKit.h
+++ b/MAThemeKit/MAThemeKit.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Mike Amaral. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface MAThemeKit : NSObject
 

--- a/MAThemeKit/MAThemeKit.m
+++ b/MAThemeKit/MAThemeKit.m
@@ -6,10 +6,11 @@
 //  Copyright (c) 2014 Mike Amaral. All rights reserved.
 //
 
+#import "MAThemeKit.h"
+
 static CGFloat const kDefaultNavigationBarFontSize = 22;
 static CGFloat const kDefaultTabBarFontSize = 14;
 
-#import "MAThemeKit.h"
 
 @implementation MAThemeKit
 


### PR DESCRIPTION
When importing `MAThemeKit` to a Swift project, I was getting an error with the Swift compiler, saying that `UIColor` and `CGFloat` weren't types. When I changed the import from Foundation to UIKit, and moved the `MAThemeKit.h` import up, it fixed the problem.

I tested by adding to the Podfile the following line:
    
    pod 'MAThemeKit', :git => 'https://github.com/andreterron/MAThemeKit.git'

You can test it by yourself by creating a swift project, with objective-C compatibility, and trying to import both libs.

If you have any concerns, please let me know